### PR TITLE
Bumped grafana image to v11.1.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     dashboard:
-        image: grafana/grafana-oss:9.4.7
+        image: grafana/grafana-oss:11.1.3
         user: $CURRENT_UID
         ports:
             - '3000:3000'


### PR DESCRIPTION
A one line change, simply bumping the base image of Grafana used from 9.4.7 to 11.1.3
