### PR TITLE
Remove dependency on mqtt_broker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,4 @@ services:
                 options:
                         tag: docker-dashboard-ui
         restart: unless-stopped
-        depends_on:
-            - "mqtt_broker"
+        


### PR DESCRIPTION
If our Service Modules are indeed modular, Solutions should be able to select their modules as freely as possible.
Whilst there will inevitably be some modules that don't work without certain others, I don't see any reason why this Grafana SM should depend on the MQTT Broker. The broker could be on another device, Telegraf could be configured to find it. 

This may impact docker-compose startup - services may not be brought up in the ideal order and containers may restart a couple of times - but I feel that is acceptable. 

(Current typical usage has a practical dependency on influxdb, but as the `datasources` directory is within `config` an alternative could be assembled in the field - influx is only the default.)