### PR TITLE
Disable SANITIZE_HTML enviroment variable in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
             - INFLUXDB_TOKEN=${DB_ADMIN_INITIAL_TOKEN}
             - INFLUXDB_ORG=${DB_ORG}
             - INFLUXDB_BUCKET=${DB_BUCKET}
+            - GF_PANELS_DISABLE_SANITIZE_HTML=true
         networks:
             internal:
                 aliases:


### PR DESCRIPTION
To support rendering HTML inc IFrames in Grafana panels. As PowerMonitoring currently does.

Do we want this to be part of the standard module that we roll out?